### PR TITLE
Added support to set mail destination address for events scripts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,7 @@ class apcupsd (
   $batterylevel   = 5,
   $minutes        = 3,
   $netserver      = 'on',
+  $maildest       = $apcupsd::params::maildest,
 ) inherits apcupsd::params {
 
   # Validate inputs
@@ -85,6 +86,37 @@ class apcupsd (
     content => template('apcupsd/apcupsd.conf.erb'),
     require => Package['apcupsd'],
     notify  => Service['apcupsd'],
+  }
+
+  # Template for scripts
+  file { 'changeme':
+    path    => "${apcupsd::scriptdir}changeme",
+    content => template('apcupsd/changeme.erb'),
+    require => Package['apcupsd'],
+  }
+
+  file { 'commfailure':
+    path    => "${apcupsd::scriptdir}commfailure",
+    content => template('apcupsd/commfailure.erb'),
+    require => Package['apcupsd'],
+  }
+
+  file { 'commok':
+    path    => "${apcupsd::scriptdir}commok",
+    content => template('apcupsd/commok.erb'),
+    require => Package['apcupsd'],
+  }
+
+  file { 'offbattery':
+    path    => "${apcupsd::scriptdir}offbattery",
+    content => template('apcupsd/offbattery.erb'),
+    require => Package['apcupsd'],
+  }
+
+  file { 'onbattery':
+    path    => "${apcupsd::scriptdir}onbattery",
+    content => template('apcupsd/onbattery.erb'),
+    require => Package['apcupsd'],
   }
 
   # Start service

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,4 +22,13 @@ class apcupsd::params {
     default  => '/etc/apcupsd/apcupsd.conf',
   }
 
+  # Script directory
+  $scriptdir = $::osfamily ? {
+    'RedHat' => '/etc/apcupsd/',
+    'Debian' => '/etc/apcupsd/',
+    default  => '/etc/apcupsd/',
+  }
+
+  $maildest = 'root'
+
 }

--- a/templates/changeme.erb
+++ b/templates/changeme.erb
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# detects that the battery should be replaced.
+# We send an email message to root to notify him.
+#
+SYSADMIN=<%= @maildest %>
+APCUPSD_MAIL="mail"
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME UPS battery needs changing NOW."
+#
+(
+   echo "Subject: $MSG"
+   echo " "
+   echo "$MSG"
+   echo " "
+   /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0

--- a/templates/commfailure.erb
+++ b/templates/commfailure.erb
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# loses contact with the UPS (i.e. the serial connection is not responding).
+# We send an email message to root to notify him.
+#
+SYSADMIN=<%= @maildest %>
+APCUPSD_MAIL="mail"
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME Communications with UPS lost"
+#
+(
+   echo "Subject: $MSG"
+   echo " "
+   echo "$MSG"
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0

--- a/templates/commok.erb
+++ b/templates/commok.erb
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when apcupsd
+# restores contact with the UPS (i.e. the serial connection is restored).
+# We send an email message to root to notify him.
+#
+SYSADMIN=<%= @maildest %>
+APCUPSD_MAIL="mail"
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME Communications with UPS restored"
+#
+(
+   echo "Subject: $MSG"
+   echo " "
+   echo "$MSG"
+   echo " "
+   /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0

--- a/templates/offbattery.erb
+++ b/templates/offbattery.erb
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when the    
+# UPS goes back on to the mains after a power failure.
+# We send an email message to root to notify him.
+#
+SYSADMIN=<%= @maildest %>
+APCUPSD_MAIL="mail"
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME Power has returned"
+#
+(
+   echo "Subject: $MSG"
+   echo " "
+   echo "$MSG"
+   echo " "
+   /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0

--- a/templates/onbattery.erb
+++ b/templates/onbattery.erb
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# This shell script if placed in /etc/apcupsd
+# will be called by /etc/apcupsd/apccontrol when the UPS
+# goes on batteries.
+# We send an email message to root to notify him.
+#
+SYSADMIN=<%= @maildest %>
+APCUPSD_MAIL="mail"
+
+HOSTNAME=`hostname`
+MSG="$HOSTNAME Power Failure !!!"
+#
+(
+   echo "Subject: $MSG"
+   echo " "
+   echo "$MSG"
+   echo " "
+   /sbin/apcaccess status
+) | $APCUPSD_MAIL -s "$MSG" $SYSADMIN
+exit 0


### PR DESCRIPTION
Hello,

I just modified your puppet module to be able to set mail recipient address for event scripts. Just set the "maildest" parameter with the desired address. The default is "root".
I used the scripts from the Debian package to populate the template directory.

Please consider merging this PR.

Thanks!
Ugo
