### PR TITLE
Add defaults file for Debian

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,15 @@ class apcupsd (
     require => Package['apcupsd'],
   }
 
+  if $apcupsd::defaults {
+    file { 'default-apcupsd':
+      path    => $apcupsd::defaults,
+      content => template('apcupsd/default-apcupsd.erb'),
+      require => Package['apcupsd'],
+      notify  => Service['apcupsd'],
+    }
+  }
+
   # Start service
   service { 'apcupsd':
     ensure  => running,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,18 @@ class apcupsd::params {
     default  => '/etc/apcupsd/apcupsd.conf',
   }
 
+  # Defaults file
+  $defaults = $::osfamily ? {
+    'Debian' => '/etc/default/apcupsd',
+    default  => undef,
+  }
+
+  $apcaccess_executable = $::osfamily ? {
+    'Debian' => '/sbin/apcaccess',
+    'RedHat' => '/usr/sbin/apcaccess',
+    default  => '/usr/sbin/apcaccess',
+  }
+
   # Script directory
   $scriptdir = $::osfamily ? {
     'RedHat' => '/etc/apcupsd/',

--- a/templates/default-apcupsd.erb
+++ b/templates/default-apcupsd.erb
@@ -1,0 +1,4 @@
+# Defaults for apcupsd initscript : File managed by Puppet - DO NOT EDIT
+
+APCACCESS=<%= scope['apcupsd::apcaccess_executable'] %>
+ISCONFIGURED=yes


### PR DESCRIPTION
… as service fails to run without ISCONFIGURED=yes in this file.

Only tested on Debian unstable, but should be OK on other releases and I expect Ubuntu too.
