### PR TITLE
add modern puppet  support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Define the type of UPS you have. Choose from `apcsmart`, `usb`, `net`, `snmp`,
 
 For USB UPSes, leave `$device` blank. For other UPS types, you must specify an
 appropriate port or address. Consult the table for example values for `$device`.
-Default: `undef`.
+Default: `''`.
 
 `$upstype` | `$device`
 -----------|-----------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,43 +36,16 @@
 # Copyright 2015 Your name here, unless otherwise noted.
 #
 class apcupsd (
-  $upsname,
-  $upscable       = 'usb',
-  $upstype        = 'usb',
-  $device         = undef,
-  $onbatterydelay = 6,
-  $batterylevel   = 5,
-  $minutes        = 3,
-  $netserver      = 'on',
-  $maildest       = $apcupsd::params::maildest,
+  String[1,8] $upsname,
+  Enum['simple','smart','ether','usb'] $upscable              = 'usb',
+  Enum['apcsmart','usb','net','snmp','dumb','pcnet'] $upstype = 'usb',
+  String $device                                              = '',
+  Integer $onbatterydelay                                     = 6,
+  Integer $batterylevel                                       = 5,
+  Integer $minutes                                            = 3,
+  Enum['on','off'] $netserver                                 = 'on',
+  String $maildest                                            = $apcupsd::params::maildest,
 ) inherits apcupsd::params {
-
-  # Validate inputs
-  validate_slength($upsname, 8)
-
-  unless $upscable in ['simple', 'smart', 'ether', 'usb'] {
-    fail('$upscable must be one of simple, smart, ether, usb')
-  }
-
-  unless $upstype in ['apcsmart', 'usb', 'net', 'snmp', 'dumb', 'pcnet'] {
-    fail('$upstype must be one of apcsmart, usb, net, snmp, dumb, pcnet')
-  }
-
-  unless is_integer($onbatterydelay) {
-    fail('$onbatterydelay must be an integer')
-  }
-
-  unless is_integer($batterylevel) {
-    fail('$batterylevel must be an integer')
-  }
-
-  unless is_integer($minutes) {
-    fail('$minutes must be an integer')
-  }
-
-  unless $netserver in ['on', 'off'] {
-    fail('$netserver must be one of on, off')
-  }
 
   # Install package
   package { 'apcupsd':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,40 +2,40 @@
 class apcupsd::params {
 
   # Name of package
-  $package = $::osfamily ? {
+  $package = $facts['osfamily'] ? {
     'RedHat' => 'apcupsd',
     'Debian' => 'apcupsd',
     default  => 'apcupsd',
   }
 
   # Name of service
-  $service = $::osfamily ? {
+  $service = $facts['osfamily'] ? {
     'RedHat' => 'apcupsd',
     'Debian' => 'apcupsd',
     default  => 'apcupsd',
   }
 
   # Config file
-  $config = $::osfamily ? {
+  $config = $facts['osfamily'] ? {
     'RedHat' => '/etc/apcupsd/apcupsd.conf',
     'Debian' => '/etc/apcupsd/apcupsd.conf',
     default  => '/etc/apcupsd/apcupsd.conf',
   }
 
   # Defaults file
-  $defaults = $::osfamily ? {
+  $defaults = $facts['osfamily'] ? {
     'Debian' => '/etc/default/apcupsd',
     default  => undef,
   }
 
-  $apcaccess_executable = $::osfamily ? {
+  $apcaccess_executable = $facts['osfamily'] ? {
     'Debian' => '/sbin/apcaccess',
     'RedHat' => '/usr/sbin/apcaccess',
     default  => '/usr/sbin/apcaccess',
   }
 
   # Script directory
-  $scriptdir = $::osfamily ? {
+  $scriptdir = $facts['osfamily'] ? {
     'RedHat' => '/etc/apcupsd/',
     'Debian' => '/etc/apcupsd/',
     default  => '/etc/apcupsd/',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "jgazeley-apcupsd",
-  "version": "0.2.1",
+  "version": "1.0.0-rc",
   "author": "jgazeley",
   "summary": "Configure apcupsd software for APC UPS devices",
   "license": "Apache-2.0",
@@ -14,14 +14,6 @@
         "5",
         "6",
         "7"
-      ]
-    },
-    {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "19",
-        "20",
-        "21"
       ]
     },
     {
@@ -39,10 +31,10 @@
       ]
     }
   ],
-  "dependencies": [
+  "requirements": [
     {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.5.0"
+      "name": "puppet",
+      "version_requirement": ">= 4.9.4 < 7.0.0"
     }
   ]
 }


### PR DESCRIPTION
validate_ functions are outdated in modern stdlib and with modern resource types they are unnecessary 

Cheers,
Vadym
