### PR TITLE
add dependencies to metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -36,5 +36,6 @@
       "name": "puppet",
       "version_requirement": ">= 4.9.4 < 7.0.0"
     }
-  ]
+  ],
+  "dependencies": [],
 }


### PR DESCRIPTION
PR #5 also requires `dependencies` to bet set in `metadata.json`, otherwise puppet 5 will fail with `[...] Could not find declared class [...]`